### PR TITLE
Add support for resuming training from intermediate checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ If you want to train the model on outdoor scenes, you should add the following c
 python train.py -s <path_to_scenes> -m <output_model_path> --outdoor --eval
 ```
 
+## Resuming Training from Checkpoint
+To resume training from a previously saved checkpoint, use the `--start_checkpoint` flag with the path to the `point_cloud_state_dict.pt` file:
+```bash
+python train.py -s <path_to_scenes> -m <output_model_path> --eval \
+    --start_checkpoint <output_model_path>/point_cloud/iteration_<N>/point_cloud_state_dict.pt
+```
+
+For example, to resume training from iteration 7000:
+```bash
+python train.py -s /path/to/scene -m /path/to/output --eval \
+    --start_checkpoint /path/to/output/point_cloud/iteration_7000/point_cloud_state_dict.pt
+```
+
+The training will automatically detect the iteration number from the checkpoint path and continue from there.
+
 ## Rendering
 To render a scene, you can use the following command:
 ```bash

--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ To render a video, you can use the following command:
 python create_video.py -m <path_to_model>
 ```
 
+## Interactive Viewing with MeshLab
+To interactively view the trained model with mouse controls (rotate, translate, zoom), first convert it to an OFF file and then open it with MeshLab:
+
+```bash
+# Convert model to OFF file
+python create_off.py \
+    --checkpoint_path <path_to_model>/point_cloud/iteration_<N>/point_cloud_state_dict.pt \
+    --output_name mesh_colored.off
+
+# View with MeshLab
+meshlab mesh_colored.off
+```
+
+MeshLab controls:
+- **Rotate**: Left click + drag
+- **Translate**: Ctrl + left click + drag (or middle click + drag)
+- **Zoom**: Scroll wheel
+
+Install MeshLab if needed: `sudo apt install meshlab` (Ubuntu/Debian) or download from [meshlab.net](https://www.meshlab.net/).
+
 ## Replication of the results
 To replicate the results of our paper, you can use the following command:
 ```bash

--- a/compile.sh
+++ b/compile.sh
@@ -6,7 +6,7 @@ cd submodules/diff-triangle-rasterization/
 rm -rf build
 rm -rf diff_triangle_rasterization.egg-info
 
-pip install .
+pip install --no-build-isolation .
 
 cd ..
 cd ..


### PR DESCRIPTION
## Summary
- Added support for resuming training from intermediate checkpoint files (`point_cloud_state_dict.pt`)
- Training automatically detects iteration number from checkpoint path (e.g., `iteration_7000`)
- Added proper initialization of tracking tensors when loading checkpoints
- Added safeguards to handle edge cases during densification after checkpoint resume
- Updated README.md with usage instructions

## Test plan
- [x] Successfully resumed training from iteration 7000 checkpoint
- [x] Training continues without errors past densification steps
- [x] Verified iteration counter correctly resumes from checkpoint

**Note:** I have already successfully tested re-training from an intermediate result (iteration 7000) and confirmed it works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)